### PR TITLE
Use ints for clip plane positions and handle initial values correctly

### DIFF
--- a/ensemble/volren/volume_render_view.enaml
+++ b/ensemble/volren/volume_render_view.enaml
@@ -6,7 +6,7 @@ from traits_enaml.widgets.mayavi_canvas import MayaviCanvas
 
 enamldef _ClipPlaneSlider(DualSlider):
     minimum = 0
-    maximum = 100
+    maximum = 512
 
 
 enamldef VolumeRenderClip(Form):
@@ -15,18 +15,18 @@ enamldef VolumeRenderClip(Form):
     Label: x_clip_label:
         text = 'X Clip'
     _ClipPlaneSlider: x_clipper:
-        low_value >> renderer.clip_bounds[0]
-        high_value >> renderer.clip_bounds[1]
+        low_value := renderer.clip_bounds[0]
+        high_value := renderer.clip_bounds[1]
     Label: y_clip_label:
         text = 'Y Clip'
     _ClipPlaneSlider: y_clipper:
-        low_value >> renderer.clip_bounds[2]
-        high_value >> renderer.clip_bounds[3]
+        low_value := renderer.clip_bounds[2]
+        high_value := renderer.clip_bounds[3]
     Label: z_clip_label:
         text = 'Z Clip'
     _ClipPlaneSlider: z_clipper:
-        low_value >> renderer.clip_bounds[4]
-        high_value >> renderer.clip_bounds[5]
+        low_value := renderer.clip_bounds[4]
+        high_value := renderer.clip_bounds[5]
 
 
 enamldef VolumeRenderView(Container):

--- a/ensemble/volren/volume_renderer.py
+++ b/ensemble/volren/volume_renderer.py
@@ -3,7 +3,7 @@ import numpy as np
 from mayavi.core.ui.api import MlabSceneModel
 from mayavi.sources.vtk_data_source import VTKDataSource
 from mayavi.tools.tools import add_dataset
-from traits.api import CInt, Float, HasTraits, Instance, List, on_trait_change
+from traits.api import CInt, HasTraits, Instance, List, on_trait_change
 from tvtk.api import tvtk
 
 from ensemble.ctf.editor import CtfEditor
@@ -11,7 +11,7 @@ from ensemble.ctf.gui_utils import get_color, get_filename
 from ensemble.volren.volume_3d import Volume3D, volume3d
 from ensemble.volren.volume_data import VolumeData
 
-CLIP_MAX = 100
+CLIP_MAX = 512
 
 
 class VolumeRenderer(HasTraits):
@@ -32,7 +32,7 @@ class VolumeRenderer(HasTraits):
     vmax = CInt(255)
 
     # Clip plane positions
-    clip_bounds = List(Float)
+    clip_bounds = List(CInt)
 
     # The transfer function editor
     ctf_editor = Instance(CtfEditor)
@@ -114,6 +114,7 @@ class VolumeRenderer(HasTraits):
     def _setup_volume(self):
         self.volume.volume_mapper.trait_set(sample_distance=0.2)
         self.volume.volume_property.trait_set(shade=False)
+        self._set_volume_clip_planes()
         self.ctf_updated()
 
     def _set_volume_clip_planes(self):


### PR DESCRIPTION
Now if you pass values for `clip_bounds` when initializing a `VolumeRenderer` you should see that reflected in the UI and rendering.
