### PR TITLE
Make the scene_members trait a Dict for easier introspection

### DIFF
--- a/ensemble/volren/tests/test_volume_renderer.py
+++ b/ensemble/volren/tests/test_volume_renderer.py
@@ -40,8 +40,11 @@ enamldef MainView(Container): view:
         volume = np.random.normal(size=(32, 32, 32))
         volume = (255*(volume-volume.min())/volume.ptp()).astype(np.uint8)
         volume_data = VolumeData(raw_data=volume)
-        scene_members = [VolumeAxes(visible_axis_scales=(True, True, True)),
-                         VolumeBoundingBox(), VolumeCutPlanes()]
+        volume_axes = VolumeAxes(visible_axis_scales=(True, True, True))
+        volume_bbox = VolumeBoundingBox()
+        volume_cut_planes = VolumeCutPlanes()
+        scene_members = {'axes': volume_axes, 'bbox': volume_bbox,
+                         'cut_planes': volume_cut_planes}
         self.viewer = VolumeViewer(volume_data=volume_data,
                                    scene_members=scene_members)
         self.view, _ = self.parse_and_create(enaml_source,

--- a/ensemble/volren/volume_viewer.py
+++ b/ensemble/volren/volume_viewer.py
@@ -1,7 +1,8 @@
 import numpy as np
 
 from mayavi.core.ui.api import MlabSceneModel
-from traits.api import Bool, CInt, HasTraits, Instance, List, on_trait_change
+from traits.api import (Bool, CInt, Dict, HasTraits, Instance, List, Str,
+                        on_trait_change)
 from tvtk.api import tvtk
 
 from ensemble.ctf.api import CtfEditor, get_color
@@ -35,7 +36,7 @@ class VolumeViewer(HasTraits):
     flip_z = Bool(False)
 
     # Additional members of the scene
-    scene_members = List(Instance(ABCVolumeSceneMember))
+    scene_members = Dict(Str, Instance(ABCVolumeSceneMember))
 
     # -------------------------------------------------------------------------
     # Public interface
@@ -99,7 +100,7 @@ class VolumeViewer(HasTraits):
 
         # Add the other members to the scene
         volume_actor = self.volume_renderer.actor
-        for member in self.scene_members:
+        for member in self.scene_members.values():
             member.add_actors_to_scene(self.model, volume_actor)
 
         self._setup_camera()

--- a/examples/volume_renderer.py
+++ b/examples/volume_renderer.py
@@ -80,7 +80,7 @@ def rescale_uint8(array):
 
 def show_volume(volume_data):
     app = QtApplication()
-    scene_members = [VolumeBoundingBox()]
+    scene_members = {'bbox': VolumeBoundingBox()}
     viewer = VolumeViewer(volume_data=volume_data, histogram_bins=256,
                           scene_members=scene_members)
     win = VolumeViewerWindow(viewer=viewer)


### PR DESCRIPTION
When you get a viewer with several scene members, it's useful to look them up by name instead of checking the types with `isinstance`...
