### PR TITLE
Make volume viewer compatible with VTK 5.10 and 6.x

### DIFF
--- a/ensemble/volren/volume_3d.py
+++ b/ensemble/volren/volume_3d.py
@@ -7,6 +7,7 @@ from mayavi.modules.volume import Volume
 from mayavi.tools.modules import DataModuleFactory, make_function
 from traits.api import Dict, Instance, Str
 from tvtk.api import tvtk
+from tvtk.common import configure_input
 
 
 class Volume3D(Volume):
@@ -73,7 +74,7 @@ class Volume3D(Volume):
         self._volume_mapper = new_vm
         self._ray_cast_functions = ray_cast_functions
 
-        new_vm.input = self.module_manager.source.outputs[0]
+        configure_input(new_vm, self.module_manager.source.outputs[0])
         self.volume.mapper = new_vm
         new_vm.on_trait_change(self.render)
 

--- a/ensemble/volren/volume_bounding_box.py
+++ b/ensemble/volren/volume_bounding_box.py
@@ -1,4 +1,5 @@
 from tvtk.api import tvtk
+from tvtk.common import configure_input
 
 from .volume_scene_member import ABCVolumeSceneMember
 
@@ -15,8 +16,10 @@ class VolumeBoundingBox(ABCVolumeSceneMember):
     def add_actors_to_scene(self, scene_model, volume_actor):
 
         # An outline of the bounds of the Volume actor's data
-        outline = tvtk.OutlineFilter(input=volume_actor.mapper.input)
-        outline_mapper = tvtk.PolyDataMapper(input=outline.output)
+        outline = tvtk.OutlineFilter()
+        configure_input(outline, volume_actor.mapper.input)
+        outline_mapper = tvtk.PolyDataMapper()
+        configure_input(outline_mapper, outline.output)
         outline_actor = tvtk.Actor(mapper=outline_mapper)
         outline_actor.property.opacity = 0.3
         scene_model.renderer.add_actor(outline_actor)

--- a/ensemble/volren/volume_data.py
+++ b/ensemble/volren/volume_data.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from traits.api import HasStrictTraits, Array, Float, Instance, Property, Tuple
 from tvtk.api import tvtk
+from tvtk.common import configure_input_data
 
 
 VolumeArray = Array(shape=(None, None, None))
@@ -43,10 +44,10 @@ def _resample_data(image_data):
     output_spacing = (spacing[0] * (dims[0] / 256.0),
                       spacing[1] * (dims[1] / 256.0),
                       spacing[2] * (dims[2] / 256.0))
-    reslicer = tvtk.ImageReslice(input=image_data,
-                                 interpolation_mode='cubic',
+    reslicer = tvtk.ImageReslice(interpolation_mode='cubic',
                                  output_extent=(0, 255, 0, 255, 0, 255),
                                  output_spacing=output_spacing)
+    configure_input_data(reslicer, image_data)
     reslicer.update()
     result = reslicer.output
     result.point_data.scalars.name = POINT_DATA_SCALARS_NAME


### PR DESCRIPTION
Fixes #41.

This uses the `tvtk.common` API to ensure the Volume Viewer related VTK pipeline configuration is compatible with VTK 6.x and backwards compatible with 5.10 as well.