### PR TITLE
More Fixes: Volume viewer vtk6 compatibility

### DIFF
--- a/ensemble/volren/tests/test_volume_renderer.py
+++ b/ensemble/volren/tests/test_volume_renderer.py
@@ -92,17 +92,20 @@ enamldef MainView(Container): view:
     def test_volume_data_masking(self):
         # Test applying mask, Pull Request #44.
 
-        # Mask is not set initially
         volume_data = self.viewer.volume_data
+        volume = volume_data.raw_data
+
+        # Mask is not set initially
         points_without_mask = volume_data.render_data.number_of_points
-        self.assertGreater(points_without_mask, 0)
+        # 256^3: that's because we are resampling the data before sending it
+        # to VTK, see `volume_data._resample_data`.
+        self.assertEqual(points_without_mask, 256 * 256 * 256)
 
         # Now apply mask
-        volume = volume_data.raw_data
         mask_data = self._example_volume_mask(volume)
         self.viewer.volume_data.mask_data = mask_data
         points_with_mask = volume_data.render_data.number_of_points
-        self.assertGreater(points_without_mask, points_with_mask)
+        self.assertEqual(points_with_mask, mask_data.size)
 
     def test_renderer_clipping_bounds(self):
         self.assertEqual(self.viewer.volume_renderer.clip_bounds, CLIP_BOUNDS)

--- a/ensemble/volren/tests/test_volume_renderer.py
+++ b/ensemble/volren/tests/test_volume_renderer.py
@@ -83,16 +83,20 @@ enamldef MainView(Container): view:
                                      scene_model.actor_list)
 
         # Ensure bounding box is computed
-        self.assertEqual(self.viewer.scene_members['bbox'].number_of_points, 8)
+        outline = self.viewer.scene_members['bbox'].outline
+        self.assertEqual(outline.output.number_of_points, 8)
 
         self.assertEqual(axes_count, 1)
         self.assertEqual(cutplane_count, 3)
 
-        # Test applying mask, Pull Request #44
+    def test_volume_data_masking(self):
+        # Test applying mask, Pull Request #44.
+
         # Mask is not set initially
         volume_data = self.viewer.volume_data
         points_without_mask = volume_data.render_data.number_of_points
         self.assertGreater(points_without_mask, 0)
+
         # Now apply mask
         volume = volume_data.raw_data
         mask_data = self._example_volume_mask(volume)

--- a/ensemble/volren/tests/test_volume_renderer.py
+++ b/ensemble/volren/tests/test_volume_renderer.py
@@ -77,12 +77,13 @@ enamldef MainView(Container): view:
         self.assertTrue(self.viewer.volume_renderer.volume is not None)
 
         # Count various actor types in the scene.
-        # XXX: The actor class for `VolumeBoundingBox` is too generic to be
-        # counted.
         scene_model = self.viewer.model
         axes_count = count_types(AXES_ACTOR_CLASS, scene_model.renderer.actors)
         cutplane_count = count_types(CUT_PLANE_ACTOR_CLASS,
                                      scene_model.actor_list)
+
+        # Ensure bounding box is computed
+        self.assertEqual(self.viewer.scene_members['bbox'].number_of_points, 8)
 
         self.assertEqual(axes_count, 1)
         self.assertEqual(cutplane_count, 3)

--- a/ensemble/volren/volume_bounding_box.py
+++ b/ensemble/volren/volume_bounding_box.py
@@ -1,4 +1,4 @@
-from traits.api import Int
+from traits.api import Instance
 from tvtk.api import tvtk
 from tvtk.common import configure_input_data
 
@@ -11,7 +11,7 @@ class VolumeBoundingBox(ABCVolumeSceneMember):
     """
 
     # The number of points should be 8 after the bounding box is computed
-    number_of_points = Int(0)
+    outline = Instance(tvtk.OutlineFilter)
 
     #--------------------------------------------------------------------------
     # ABCVolumeSceneMember interface
@@ -21,9 +21,9 @@ class VolumeBoundingBox(ABCVolumeSceneMember):
 
         # An outline of the bounds of the Volume actor's data
         outline = tvtk.OutlineFilter()
+        self.outline = outline
         configure_input_data(outline, volume_actor.mapper.input)
         outline.update()
-        self.number_of_points = outline.output.number_of_points
         outline_mapper = tvtk.PolyDataMapper()
         configure_input_data(outline_mapper, outline.output)
         outline_actor = tvtk.Actor(mapper=outline_mapper)

--- a/ensemble/volren/volume_bounding_box.py
+++ b/ensemble/volren/volume_bounding_box.py
@@ -1,5 +1,5 @@
 from tvtk.api import tvtk
-from tvtk.common import configure_input
+from tvtk.common import configure_input_data
 
 from .volume_scene_member import ABCVolumeSceneMember
 
@@ -17,9 +17,10 @@ class VolumeBoundingBox(ABCVolumeSceneMember):
 
         # An outline of the bounds of the Volume actor's data
         outline = tvtk.OutlineFilter()
-        configure_input(outline, volume_actor.mapper.input)
+        configure_input_data(outline, volume_actor.mapper.input)
+        outline.update()
         outline_mapper = tvtk.PolyDataMapper()
-        configure_input(outline_mapper, outline.output)
+        configure_input_data(outline_mapper, outline.output)
         outline_actor = tvtk.Actor(mapper=outline_mapper)
         outline_actor.property.opacity = 0.3
         scene_model.renderer.add_actor(outline_actor)

--- a/ensemble/volren/volume_bounding_box.py
+++ b/ensemble/volren/volume_bounding_box.py
@@ -1,3 +1,4 @@
+from traits.api import Int
 from tvtk.api import tvtk
 from tvtk.common import configure_input_data
 
@@ -9,6 +10,9 @@ class VolumeBoundingBox(ABCVolumeSceneMember):
     Volume.
     """
 
+    # The number of points should be 8 after the bounding box is computed
+    number_of_points = Int(0)
+
     #--------------------------------------------------------------------------
     # ABCVolumeSceneMember interface
     #--------------------------------------------------------------------------
@@ -19,6 +23,7 @@ class VolumeBoundingBox(ABCVolumeSceneMember):
         outline = tvtk.OutlineFilter()
         configure_input_data(outline, volume_actor.mapper.input)
         outline.update()
+        self.number_of_points = outline.output.number_of_points
         outline_mapper = tvtk.PolyDataMapper()
         configure_input_data(outline_mapper, outline.output)
         outline_actor = tvtk.Actor(mapper=outline_mapper)

--- a/ensemble/volren/volume_data.py
+++ b/ensemble/volren/volume_data.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from traits.api import HasStrictTraits, Array, Float, Instance, Property, Tuple
 from tvtk.api import tvtk
-from tvtk.common import configure_input_data
+from tvtk.common import configure_input_data, is_old_pipeline
 
 
 VolumeArray = Array(shape=(None, None, None))
@@ -16,8 +16,12 @@ def _apply_mask(volume_data, mask_data):
     """
     mask_image_data = _image_data_from_array(mask_data, volume_data.spacing)
     masker = tvtk.ImageMask()
-    masker.set_image_input(volume_data)
-    masker.set_mask_input(mask_image_data)
+    if is_old_pipeline():
+        masker.set_image_input(volume_data)
+        masker.set_mask_input(mask_image_data)
+    else:
+        masker.set_image_input_data(volume_data)
+        masker.set_mask_input_data(mask_image_data)
     masker.update()
     result = masker.output
     result.point_data.scalars.name = POINT_DATA_SCALARS_NAME


### PR DESCRIPTION
This fixes:
*  the bounding box outline filter which needs an `update` and 
* `MaskImage` which has a different API for setting mask and image inputs in VTK 6.x onwards. 