### PR TITLE
Generate high resolution screenshot for volume viewer

### DIFF
--- a/ensemble/volren/tests/test_volume_renderer.py
+++ b/ensemble/volren/tests/test_volume_renderer.py
@@ -78,9 +78,19 @@ enamldef MainView(Container): view:
         self.assertEqual(self.viewer.volume_renderer.clip_bounds, CLIP_BOUNDS)
 
     def test_renderer_screenshot(self):
+        # With default resolution
         image_array = self.viewer.screenshot()
+        s1 = image_array.size
         self.assertTrue(image_array.ndim == 3)
         self.assertTrue(image_array.shape[-1] == 3)
+
+        # With higher resolution
+        magnification = 3
+        image_array = self.viewer.screenshot(magnification=magnification)
+        s2 = image_array.size
+        self.assertTrue(image_array.ndim == 3)
+        self.assertTrue(image_array.shape[-1] == 3)
+        self.assertEqual(s2 / s1, magnification * magnification)
 
 if __name__ == "__main__":
     unittest.main()

--- a/ensemble/volren/volume_viewer.py
+++ b/ensemble/volren/volume_viewer.py
@@ -45,15 +45,21 @@ class VolumeViewer(HasTraits):
     # Public interface
     # -------------------------------------------------------------------------
 
-    def screenshot(self):
+    def screenshot(self, magnification=1):
         """ Returns an image of the rendered volume. The image will be the same
-        size as the window on screen.
+        size as the window on screen by default. For high resolution image,
+        pass a magnification integer value > 1.
         """
-        render_window = self.model.render_window
-        x, y = render_window.size
+        renderer = self.model.renderer
 
-        data = tvtk.UnsignedCharArray()
-        render_window.get_pixel_data(0, 0, x - 1, y - 1, 1, data)
+        image_filter = tvtk.RenderLargeImage()
+        image_filter.input = renderer
+        image_filter.magnification = magnification
+        image_filter.update()
+
+        image_data = image_filter.output
+        x, y, _ = image_data.dimensions
+        data = image_data.point_data.scalars
         data_array = data.to_array().copy()
         data_array.shape = (y, x, 3)
         data_array = np.flipud(data_array)


### PR DESCRIPTION
This uses the `RenderLargeImage` filter to generate a high resolution image.

* The default resolution is 1. Passing `magnification=k` where k > 1 generates a higher resolution image.
* Added tests for both default and high resolution images.