### PR TITLE
[WIP]: Add volume data filters

### DIFF
--- a/ensemble/volren/api.py
+++ b/ensemble/volren/api.py
@@ -3,6 +3,7 @@ from .volume_axes import VolumeAxes  # noqa
 from .volume_bounding_box import VolumeBoundingBox  # noqa
 from .volume_cut_planes import VolumeCutPlanes  # noqa
 from .volume_data import VolumeData  # noqa
+from .volume_data_filter import VolumeFilter # noqa
 from .volume_renderer import VolumeRenderer  # noqa
 from .volume_scene_member import ABCVolumeSceneMember  # noqa
 from .volume_viewer import VolumeViewer  # noqa

--- a/ensemble/volren/volume_data.py
+++ b/ensemble/volren/volume_data.py
@@ -4,6 +4,7 @@ from traits.api import HasStrictTraits, Array, Float, Instance, Property, Tuple
 from tvtk.api import tvtk
 from tvtk.common import configure_input_data, is_old_pipeline
 
+from .volume_data_filter import VolumeFilter
 
 VolumeArray = Array(shape=(None, None, None))
 
@@ -75,6 +76,10 @@ class VolumeData(HasStrictTraits):
     # The data as a fortran array
     _raw_data = VolumeArray
 
+    # The filter to apply to the raw data
+    volume_filter = Property(Instance(VolumeFilter))
+    _volume_filter = Instance(VolumeFilter)
+
     # The bounds of the volume
     bounds = Tuple(Float, Float, Float)
 
@@ -122,6 +127,10 @@ class VolumeData(HasStrictTraits):
     def _set_raw_data(self, value):
         self._render_data = None
         self._raw_data = np.asfortranarray(value)
+
+    def _set_volume_filter(self, value):
+        self._volume_filter = value
+        self.raw_data = self._volume_filter.filter(self.raw_data)
 
     # -------------------------------------------------------------------------
     # Private methods

--- a/ensemble/volren/volume_data_filter.py
+++ b/ensemble/volren/volume_data_filter.py
@@ -1,0 +1,11 @@
+class VolumeFilter():
+    """ This is the default volume data filter. 
+        Subclass this filter to transform the volume data.
+    """
+    name = 'Default'
+
+    def filter(self, raw_data):
+        """ Transform the volume data raw_data.
+            Override this implementation to apply custom transformation.
+        """
+        return raw_data


### PR DESCRIPTION
This adds a default implementation to transform the `VolumeData.raw_data` property.

When the `volume_filter` of `VolumeData` is set, the `raw_data` is recomputed which results in reloading the histogram and the 3D volume.

- [ ] Update/add tests for `VolumeData`
- [ ] Refactor the masking functionality into a `VolumeFilter` subclass. See: https://github.com/enthought/ensemble/issues/46#issuecomment-147073792