### PR TITLE
Use trapezoidal window in CTF

### DIFF
--- a/ensemble/ctf/editor.py
+++ b/ensemble/ctf/editor.py
@@ -8,7 +8,7 @@ from .color_function_component import ColorNode, ColorComponent
 from .function_component import FunctionComponent
 from .window_function_component import (
     WindowComponent, WindowColorNode, WindowOpacityNode,
-    MINIMUM_RADIUS
+    DEFAULT_RADIUS
 )
 from .menu_tool import menu_tool_with_actions
 from .opacity_function_component import OpacityNode, OpacityComponent
@@ -54,7 +54,7 @@ class AddWindowAction(BaseColorAction):
     def perform_with_color(self, event, color):
         screen_position = (event.enable_event.x, event.enable_event.y)
         rel_x, rel_y = self.screen_to_function(screen_position)
-        rad = MINIMUM_RADIUS
+        rad = DEFAULT_RADIUS
 
         color_node = WindowColorNode(center=rel_x, color=color, radius=rad)
         opacity_node = WindowOpacityNode(center=rel_x, opacity=rel_y,

--- a/ensemble/ctf/tests/test_utils.py
+++ b/ensemble/ctf/tests/test_utils.py
@@ -1,0 +1,23 @@
+import unittest
+
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from ensemble.ctf.utils import trapezoid_window
+
+
+class TestTrapezoidWindow(unittest.TestCase):
+
+    def test_empty_window(self):
+        w = trapezoid_window(0)
+        assert_array_equal(w, np.array([]))
+
+    def test_basic_window(self):
+        w = trapezoid_window(5)
+        window_start = w[0]
+        window_center = w[1:4]
+        window_stop = w[4]
+
+        assert_array_equal(window_center, np.ones((3)))
+        self.assertEqual(window_start, 0)
+        self.assertEqual(window_stop, 0)

--- a/ensemble/ctf/utils.py
+++ b/ensemble/ctf/utils.py
@@ -1,5 +1,7 @@
 import json
 
+import numpy as np
+
 from .transfer_function import TransferFunction
 
 
@@ -33,3 +35,25 @@ def save_ctf(transfer_func, filename):
     function_data = transfer_func.to_dict()
     with open(filename, 'wb') as fp:
         json.dump(function_data, fp, indent=1)
+
+
+def trapezoid_window(num_points):
+    """ Return a window where endpoints are 0 and all other points are 1.0.
+
+    Similar to boxcar or rectangular window in ``scipy.signal`` but with
+    endpoints of 0.
+
+    Parameters
+    ----------
+    num_points : int
+        Number of points in the output window. If zero or less, an empty array
+        is returned.
+    """
+    if num_points <= 0:
+        return np.array([], dtype='float64')
+    w = np.ones(num_points, dtype='float64')
+
+    # Set endpoints of window
+    w[0] = 0
+    w[-1] = 0
+    return w

--- a/ensemble/ctf/window_function_component.py
+++ b/ensemble/ctf/window_function_component.py
@@ -1,5 +1,4 @@
 import numpy as np
-from scipy.signal import hanning
 
 from traits.api import Callable, Enum, Instance, on_trait_change
 
@@ -9,7 +8,7 @@ from .function_node import (register_function_node_class,
                             register_function_node_class_for_back_compat)
 from .movable_component import MovableComponent
 from .opacity_function_component import OpacityNode
-from .utils import clip_to_unit
+from .utils import clip_to_unit, trapezoid_window
 
 
 HEIGHT_WIDGET_THICKNESS = 6.0
@@ -37,14 +36,14 @@ class WindowColorNode(ColorNode):
 
 
 class WindowOpacityNode(OpacityNode):
-    """ An `OpacityNode` with a non-zero radius and a Hanning shape.
+    """ An `OpacityNode` with a non-zero radius and a trapezoidal shape.
     """
     def values(self):
         center, radius = self.center, self.radius
         num_samples = int(np.round(radius * 2.0 * MAX_NUM_SAMPLES))
 
         xs = np.linspace(center - radius, center + radius, num_samples)
-        ys = hanning(num_samples) * self.opacity
+        ys = trapezoid_window(num_samples) * self.opacity
         return zip(xs, ys)
 
 
@@ -88,7 +87,7 @@ class WindowHeightWidget(MovableComponent):
 
 class WindowComponent(BaseColorComponent):
     """ A `BaseColorComponent` which has some radius and both color and
-    opacity, with the opacity determined by a Hanning function.
+    opacity, with the opacity determined by a window function.
     """
 
     # The opacity node
@@ -130,7 +129,7 @@ class WindowComponent(BaseColorComponent):
         color_node = _get_node(nodes, WindowColorNode)
         opacity_node = _get_node(nodes, WindowOpacityNode)
         if len(nodes) != 2 and (color_node is None or opacity_node is None):
-            raise ValueError('Expecting two Hanning function nodes!')
+            raise ValueError('Expecting two window function nodes!')
 
         return cls(node=color_node, opacity_node=opacity_node)
 

--- a/ensemble/ctf/window_function_component.py
+++ b/ensemble/ctf/window_function_component.py
@@ -18,6 +18,7 @@ GRAY = (0.6, 0.6, 0.6, 1.0)
 POINTER_MAP = {'move': 'hand', 'resize': 'size left'}
 MAX_NUM_SAMPLES = 256
 MINIMUM_RADIUS = 0.005
+DEFAULT_RADIUS = 2 * MINIMUM_RADIUS
 
 
 def _get_node(nodes, node_class):


### PR DESCRIPTION
A follow-up to #51, after discussion with @eric-jones.

A [`tukey` window](http://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.tukey.html) is probably what we want to use here, but that's not available in the version of `scipy` we're currently using.
