### PR TITLE
Str/Unicode fixes

### DIFF
--- a/ensemble/ctf/base_color_function_component.py
+++ b/ensemble/ctf/base_color_function_component.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from pyface.action.api import Action
 from traits.api import Callable, Float, Instance, Tuple
 

--- a/ensemble/ctf/color_function_component.py
+++ b/ensemble/ctf/color_function_component.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from .base_color_function_component import BaseColorComponent, ColorNode
 from .function_component import register_function_component_class
 from .function_node import register_function_node_class

--- a/ensemble/ctf/editor.py
+++ b/ensemble/ctf/editor.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import numpy as np
 
 from enable.api import ColorTrait, Container

--- a/ensemble/ctf/editor.py
+++ b/ensemble/ctf/editor.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import numpy as np
 
 from enable.api import ColorTrait, Container
@@ -205,7 +207,9 @@ class CtfEditor(Container):
 
         with gc:
             gc.rect(0, 0, w, h)
-            gc.linear_gradient(0, 0, w, 0, grad_stops, 'pad', 'userSpaceOnUse')
+            # XXX : We need to pass byte strings instead of unicode strings.
+            # See https://github.com/enthought/enable/issues/342
+            gc.linear_gradient(0, 0, w, 0, grad_stops, b'pad', b'userSpaceOnUse')
             gc.fill_path()
 
     def _draw_histogram(self, gc):

--- a/ensemble/ctf/editor.py
+++ b/ensemble/ctf/editor.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import numpy as np
 
 from enable.api import ColorTrait, Container

--- a/ensemble/ctf/function_component.py
+++ b/ensemble/ctf/function_component.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from traits.api import Bool, Float, Instance, Property, Tuple
 
 from .function_node import FunctionNode

--- a/ensemble/ctf/function_node.py
+++ b/ensemble/ctf/function_node.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from abc import abstractmethod
 
 from traits.api import ABCHasStrictTraits, Float

--- a/ensemble/ctf/gui_utils.py
+++ b/ensemble/ctf/gui_utils.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from enaml.colors import Color
 import traits_enaml
 

--- a/ensemble/ctf/manager.py
+++ b/ensemble/ctf/manager.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from base64 import urlsafe_b64encode, urlsafe_b64decode
 import glob
 import os
@@ -12,11 +14,13 @@ CTF_EXTENSION = '.ctf'
 
 
 def _name_encode(name):
-    return urlsafe_b64encode(name.encode('utf-8'))
+    # Accepts a unicode input and returns a unicode output
+    return urlsafe_b64encode(name.encode('utf-8')).decode('utf-8')
 
 
 def _name_decode(name):
-    return urlsafe_b64decode(name).decode('utf-8')
+    # Accepts a unicode input and returns a unicode output
+    return urlsafe_b64decode(name.encode('utf-8')).decode('utf-8')
 
 
 class CtfManager(HasStrictTraits):

--- a/ensemble/ctf/manager.py
+++ b/ensemble/ctf/manager.py
@@ -2,7 +2,7 @@ from base64 import urlsafe_b64encode, urlsafe_b64decode
 import glob
 import os
 
-from traits.api import HasStrictTraits, Dict, Instance, List, Str
+from traits.api import HasStrictTraits, Dict, Instance, List, Unicode
 
 from .transfer_function import TransferFunction
 from .utils import load_ctf, save_ctf
@@ -24,13 +24,13 @@ class CtfManager(HasStrictTraits):
     """
 
     # The root directory with the files.
-    root_dir = Str('.')
+    root_dir = Unicode('.')
 
     # The available CTFs.
-    names = List(Str)
+    names = List(Unicode)
 
     # The transfer functions by name.
-    functions = Dict(Str, Instance(TransferFunction))
+    functions = Dict(Unicode, Instance(TransferFunction))
 
     @classmethod
     def from_directory(cls, root_dir, **traits):

--- a/ensemble/ctf/menu_tool.py
+++ b/ensemble/ctf/menu_tool.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from enable.component import Component
 from enable.tools.pyface.context_menu_tool import ContextMenuTool
 from pyface.action.api import Action, Group, MenuManager

--- a/ensemble/ctf/movable_component.py
+++ b/ensemble/ctf/movable_component.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from enable.api import Container
 from enable.toolkit_constants import pointer_names
 from traits.api import Enum, Float

--- a/ensemble/ctf/opacity_function_component.py
+++ b/ensemble/ctf/opacity_function_component.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from traits.api import Float
 
 from .function_component import (FunctionComponent,

--- a/ensemble/ctf/piecewise.py
+++ b/ensemble/ctf/piecewise.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from bisect import bisect
 from operator import add, sub
 

--- a/ensemble/ctf/tests/test_editor.py
+++ b/ensemble/ctf/tests/test_editor.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 
 from enable.testing import EnableTestAssistant

--- a/ensemble/ctf/tests/test_editor.py
+++ b/ensemble/ctf/tests/test_editor.py
@@ -21,7 +21,7 @@ class TestEditor(EnamlTestAssistant, EnableTestAssistant, unittest.TestCase):
     def setUp(self):
         EnamlTestAssistant.setUp(self)
 
-        enaml_source = """
+        enaml_source = b"""
 from enaml.widgets.api import MainWindow
 from traits_enaml.widgets.enable_canvas import EnableCanvas
 

--- a/ensemble/ctf/tests/test_manager.py
+++ b/ensemble/ctf/tests/test_manager.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from contextlib import contextmanager
 from os import listdir
 import shutil
@@ -71,7 +72,7 @@ def _test_ctf_manager_names(names_to_test):
 
 def test_ctf_manager_crazy_names():
     # Handle unicode and slashes
-    crazy_names = [u'他妈的！// what?', u'/this/looks/like/a/path/Ø']
+    crazy_names = ['他妈的！// what?', '/this/looks/like/a/path/Ø']
     _test_ctf_manager_names(crazy_names)
 
 

--- a/ensemble/ctf/transfer_function.py
+++ b/ensemble/ctf/transfer_function.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from traits.api import HasStrictTraits, Event, Instance, List, Property
 
 from .piecewise import PiecewiseFunction

--- a/ensemble/ctf/utils.py
+++ b/ensemble/ctf/utils.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import json
 
 import numpy as np

--- a/ensemble/ctf/window_function_component.py
+++ b/ensemble/ctf/window_function_component.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import numpy as np
 from scipy.signal import hanning
 

--- a/ensemble/volren/tests/test_volume_renderer.py
+++ b/ensemble/volren/tests/test_volume_renderer.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import os
 import unittest
 

--- a/ensemble/volren/tests/test_volume_renderer.py
+++ b/ensemble/volren/tests/test_volume_renderer.py
@@ -34,7 +34,7 @@ class VolumeViewerTestCase(EnamlTestAssistant, unittest.TestCase):
 
         EnamlTestAssistant.setUp(self)
 
-        enaml_source = """
+        enaml_source = b"""
 from enaml.widgets.api import Container
 from ensemble.volren.volume_viewer_ui import VolumeViewerContainer
 

--- a/ensemble/volren/volume_3d.py
+++ b/ensemble/volren/volume_3d.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from mayavi.core.trait_defs import DEnum
 from mayavi.modules.volume import Volume
 from mayavi.tools.modules import DataModuleFactory, make_function

--- a/ensemble/volren/volume_3d.py
+++ b/ensemble/volren/volume_3d.py
@@ -1,7 +1,7 @@
 from mayavi.core.trait_defs import DEnum
 from mayavi.modules.volume import Volume
 from mayavi.tools.modules import DataModuleFactory, make_function
-from traits.api import Instance, Str
+from traits.api import Instance, Unicode
 
 
 class Volume3D(Volume):
@@ -20,8 +20,8 @@ class Volume3DFactory(DataModuleFactory):
     """ Applies the Volume3D Mayavi module to the given VTK data source.
     """
     _target = Instance(Volume3D, ())
-    volume_mapper_type = Str('SmartVolumeMapper',
-                             adapts='volume_mapper_type')
+    volume_mapper_type = Unicode('SmartVolumeMapper',
+                                 adapts='volume_mapper_type')
 
 
 volume3d = make_function(Volume3DFactory)

--- a/ensemble/volren/volume_axes.py
+++ b/ensemble/volren/volume_axes.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from traits.api import Bool, Enum, Float, Tuple, Unicode
 from tvtk.api import tvtk
 

--- a/ensemble/volren/volume_axes.py
+++ b/ensemble/volren/volume_axes.py
@@ -1,4 +1,4 @@
-from traits.api import Bool, Enum, Float, Str, Tuple
+from traits.api import Bool, Enum, Float, Tuple, Unicode
 from tvtk.api import tvtk
 
 from .volume_scene_member import ABCVolumeSceneMember
@@ -21,13 +21,13 @@ class VolumeAxes(ABCVolumeSceneMember):
     visible_axis_scales = Tuple(Bool, Bool, Bool)
 
     # Axes titles.
-    axis_titles = Tuple(Str, Str, Str)
+    axis_titles = Tuple(Unicode, Unicode, Unicode)
 
     # Axes units.
-    axis_units = Tuple(Str, Str, Str)
+    axis_units = Tuple(Unicode, Unicode, Unicode)
 
     # Axes labels format.
-    axis_label_formats = Tuple(Str, Str, Str)
+    axis_label_formats = Tuple(Unicode, Unicode, Unicode)
 
     # Fly mode, determining the position of the axes on the bounding box.
     fly_mode = Enum(('static_triad', 'closest_triad', 'furthest_triad',

--- a/ensemble/volren/volume_bounding_box.py
+++ b/ensemble/volren/volume_bounding_box.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from traits.api import Instance
 from tvtk.api import tvtk
 from tvtk.common import configure_input_data

--- a/ensemble/volren/volume_cut_planes.py
+++ b/ensemble/volren/volume_cut_planes.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 from mayavi import mlab
 from mayavi.core.api import PipelineBase
-from traits.api import Enum, Instance, List, Range, Str, on_trait_change
+from traits.api import Enum, Instance, List, Range, on_trait_change, Unicode
 
 from .volume_scene_member import ABCVolumeSceneMember
 
@@ -24,7 +24,7 @@ class VolumeCutPlanes(ABCVolumeSceneMember):
     image_plane_widget_z = Instance(PipelineBase)
 
     # Colormap selection
-    available_cut_colormaps = List(Str, CUT_COLORMAPS.keys())
+    available_cut_colormaps = List(Unicode, CUT_COLORMAPS.keys())
     selected_cut_color_map = Enum(values='available_cut_colormaps')
 
     # A global multiplier to the opacity transfer function.

--- a/ensemble/volren/volume_cut_planes.py
+++ b/ensemble/volren/volume_cut_planes.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from collections import OrderedDict
 
 from mayavi import mlab
@@ -8,9 +9,9 @@ from .volume_scene_member import ABCVolumeSceneMember
 
 
 CUT_COLORMAPS = OrderedDict([
-    (u'Gray', 'gray'),
-    (u'Bone', 'bone'),
-    (u'RdBu', 'RdBu'),
+    ('Gray', 'gray'),
+    ('Bone', 'bone'),
+    ('RdBu', 'RdBu'),
 ])
 
 

--- a/ensemble/volren/volume_data.py
+++ b/ensemble/volren/volume_data.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import numpy as np
 
 from traits.api import HasStrictTraits, Array, Float, Instance, Property, Tuple

--- a/ensemble/volren/volume_renderer.py
+++ b/ensemble/volren/volume_renderer.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from mayavi.sources.vtk_data_source import VTKDataSource
 from mayavi.tools.tools import add_dataset
 from traits.api import (HasStrictTraits, CInt, Enum, Instance, List, Property,

--- a/ensemble/volren/volume_scene_member.py
+++ b/ensemble/volren/volume_scene_member.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from abc import abstractmethod
 
 from traits.api import ABCHasStrictTraits

--- a/ensemble/volren/volume_viewer.py
+++ b/ensemble/volren/volume_viewer.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from mayavi.core.ui.api import MlabSceneModel
 from traits.api import (Bool, CInt, Dict, Event, HasTraits, Instance, List,
-                        Str, on_trait_change)
+                        on_trait_change, Unicode)
 from tvtk.api import tvtk
 
 from ensemble.ctf.api import CtfEditor, get_color
@@ -36,7 +36,7 @@ class VolumeViewer(HasTraits):
     flip_z = Bool(False)
 
     # Additional members of the scene
-    scene_members = Dict(Str, Instance(ABCVolumeSceneMember))
+    scene_members = Dict(Unicode, Instance(ABCVolumeSceneMember))
 
     # An event fired once the scene has been initialized.
     scene_initialized = Event

--- a/ensemble/volren/volume_viewer.py
+++ b/ensemble/volren/volume_viewer.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import numpy as np
 
 from mayavi.core.ui.api import MlabSceneModel


### PR DESCRIPTION
- Replace `Str` trait type with `Unicode`
- Add `from __future__ import unicode_literals` to all files.

The problem with using the `Str` trait type is the fact that it will accept both bytes and unicode data, which can lead to confusion. It is better to constraint the data/value by using the `Unicode` trait type.

This will help ensure that the behavior on Python 2 and 3 are the same.