### PR TITLE
Python 2/3 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ matrix:
 before_install:
   - mkdir -p "${HOME}/.cache/download"
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - sh -e install-edm-linux.sh
-  - export PATH="${HOME}/edm/bin:${PATH}"
+  - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sh -e /etc/init.d/xvfb start; fi
+  - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
+  - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - export ETS_TOOLKIT=qt4
   - export IS_CI=1
   - edm install -y wheel click coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,16 @@ cache:
   directories:
     - "~/.cache"
 
+matrix:
+  include:
+    - env: RUNTIME=2.7 TOOLKIT="pyside"
+    - env: RUNTIME=3.6 TOOLKIT="pyqt"
+    - os: osx
+      env: RUNTIME=2.7 TOOLKIT="pyside"
+    - os: osx
+      env: RUNTIME=3.6 TOOLKIT="pyqt"
+  fast_finish: true
+
 before_install:
   - mkdir -p "${HOME}/.cache/download"
   - export DISPLAY=:99.0
@@ -19,9 +29,9 @@ before_install:
   - export IS_CI=1
   - edm install -y wheel click coverage
 install:
-  - edm run -- python -m etstool install
+  - edm run -- python -m etstool install --runtime=${RUNTIME} --toolkit=${TOOLKIT}
 script:
-  - edm run -- python -m etstool test
+  - edm run -- python -m etstool test --runtime=${RUNTIME} --toolkit=${TOOLKIT}
 after_success:
   - edm run -- coverage combine
   - edm run -- pip install codecov

--- a/ensemble/ctf/color_function_component.py
+++ b/ensemble/ctf/color_function_component.py
@@ -1,4 +1,5 @@
-from __future__ import unicode_literals
+from __future__ import division, unicode_literals
+
 from .base_color_function_component import BaseColorComponent, ColorNode
 from .function_component import register_function_component_class
 from .function_node import register_function_node_class
@@ -29,7 +30,7 @@ class ColorComponent(BaseColorComponent):
             # FIXME: Bad choice of contrasting color for grays.
             opposite_color = (1.0 - r, 1.0 - g, 1.0 - b, 1.0)
             gc.set_fill_color(opposite_color)
-            gc.rect(screen_x - COMPONENT_WIDTH/2.0, 0, COMPONENT_WIDTH, height)
+            gc.rect(screen_x - COMPONENT_WIDTH/2, 0, COMPONENT_WIDTH, height)
             gc.draw_path()
 
     @classmethod
@@ -73,7 +74,7 @@ class ColorComponent(BaseColorComponent):
 
     def _sync_component_position(self):
         screen_x, _ = self.relative_to_screen(self.node.center, 0.0)
-        self.position = (screen_x - COMPONENT_WIDTH/2.0, 0.0)
+        self.position = (screen_x - COMPONENT_WIDTH/2, 0.0)
 
 
 # Register our function node

--- a/ensemble/ctf/editor.py
+++ b/ensemble/ctf/editor.py
@@ -18,6 +18,13 @@ from .opacity_function_component import OpacityNode, OpacityComponent
 from .transfer_function import TransferFunction
 from .utils import build_screen_to_function
 
+# XXX : We need to pass byte strings instead of unicode strings on Python 2.
+# See https://github.com/enthought/enable/issues/342
+if six.PY2:
+    LINEAR_GRADIENT_ARGS = (b'pad', b'userSpaceOnUse')
+else:
+    LINEAR_GRADIENT_ARGS = ('pad', 'userSpaceOnUse')
+
 
 class BaseCtfEditorAction(Action):
     container = Instance(Container)
@@ -208,13 +215,8 @@ class CtfEditor(Container):
 
         with gc:
             gc.rect(0, 0, w, h)
-            # XXX : We need to pass byte strings instead of unicode strings.
-            # See https://github.com/enthought/enable/issues/342
-            if six.PY2:
-                args = (b'pad', b'userSpaceOnUse')
-            else:
-                args = ('pad', 'userSpaceOnUse')
-            gc.linear_gradient(0, 0, w, 0, grad_stops, *args)
+
+            gc.linear_gradient(0, 0, w, 0, grad_stops, *LINEAR_GRADIENT_ARGS)
             gc.fill_path()
 
     def _draw_histogram(self, gc):

--- a/ensemble/ctf/editor.py
+++ b/ensemble/ctf/editor.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import numpy as np
+import six
 
 from enable.api import ColorTrait, Container
 from pyface.action.api import Action
@@ -209,7 +210,11 @@ class CtfEditor(Container):
             gc.rect(0, 0, w, h)
             # XXX : We need to pass byte strings instead of unicode strings.
             # See https://github.com/enthought/enable/issues/342
-            gc.linear_gradient(0, 0, w, 0, grad_stops, b'pad', b'userSpaceOnUse')
+            if six.PY2:
+                args = (b'pad', b'userSpaceOnUse')
+            else:
+                args = ('pad', 'userSpaceOnUse')
+            gc.linear_gradient(0, 0, w, 0, grad_stops, *args)
             gc.fill_path()
 
     def _draw_histogram(self, gc):

--- a/ensemble/ctf/editor.py
+++ b/ensemble/ctf/editor.py
@@ -173,8 +173,8 @@ class CtfEditor(Container):
     # -----------------------------------------------------------------------
 
     def _draw_container_mainlayer(self, gc, *args, **kwargs):
-        color_nodes = self.function.color.values()
-        alpha_nodes = self.function.opacity.values()
+        color_nodes = list(self.function.color.values())
+        alpha_nodes = list(self.function.opacity.values())
 
         gc.clear()
 

--- a/ensemble/ctf/editor.py
+++ b/ensemble/ctf/editor.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import division, unicode_literals
 
 import numpy as np
 import six
@@ -227,14 +227,14 @@ class CtfEditor(Container):
         values = values.astype(float)
         zeros = (values == 0)
         min_nonzero = values[~zeros].min()
-        values[zeros] = min_nonzero / 2.0
+        values[zeros] = min_nonzero / 2
         log_values = np.log(values)
         log_values -= log_values.min()
         log_values /= log_values.max()
 
         h_values = log_values * h
         bin_edges = bin_edges - bin_edges.min()
-        bin_edges *= w / bin_edges.max()
+        bin_edges *= w // bin_edges.max()
         x = np.concatenate([bin_edges[:1],
                             np.repeat(bin_edges[1:-1], 2),
                             bin_edges[-1:]])

--- a/ensemble/ctf/editor.py
+++ b/ensemble/ctf/editor.py
@@ -234,7 +234,7 @@ class CtfEditor(Container):
 
         h_values = log_values * h
         bin_edges = bin_edges - bin_edges.min()
-        bin_edges *= w // bin_edges.max()
+        bin_edges *= w / bin_edges.max()
         x = np.concatenate([bin_edges[:1],
                             np.repeat(bin_edges[1:-1], 2),
                             bin_edges[-1:]])

--- a/ensemble/ctf/editor.py
+++ b/ensemble/ctf/editor.py
@@ -173,8 +173,8 @@ class CtfEditor(Container):
     # -----------------------------------------------------------------------
 
     def _draw_container_mainlayer(self, gc, *args, **kwargs):
-        color_nodes = list(self.function.color.values())
-        alpha_nodes = list(self.function.opacity.values())
+        color_nodes = self.function.color.values()
+        alpha_nodes = self.function.opacity.values()
 
         gc.clear()
 

--- a/ensemble/ctf/function_component.py
+++ b/ensemble/ctf/function_component.py
@@ -1,4 +1,5 @@
-from __future__ import unicode_literals
+from __future__ import division, unicode_literals
+
 from traits.api import Bool, Float, Instance, Property, Tuple
 
 from .function_node import FunctionNode
@@ -77,7 +78,7 @@ class FunctionComponent(MovableComponent):
 
     def screen_to_relative(self, x, y):
         parent_width, parent_height = self.parent_bounds
-        return (x / float(parent_width), y / float(parent_height))
+        return (x / parent_width, y / parent_height)
 
     def update_node_center(self, node, rel_x):
         min_c, max_c = self._center_limits

--- a/ensemble/ctf/gui_utils.py
+++ b/ensemble/ctf/gui_utils.py
@@ -1,4 +1,5 @@
-from __future__ import unicode_literals
+from __future__ import division, unicode_literals
+
 from enaml.colors import Color
 import traits_enaml
 
@@ -12,7 +13,7 @@ def get_color(starting_color=None):
     If no color is selected (because the user cancels the dialog), return None.
     """
     def color_as_tuple(color):
-        return (color.red/255., color.green/255., color.blue/255.)
+        return (color.red/255, color.green/255, color.blue/255)
 
     def tuple_as_color(tup):
         r, g, b = tup

--- a/ensemble/ctf/opacity_function_component.py
+++ b/ensemble/ctf/opacity_function_component.py
@@ -1,4 +1,5 @@
-from __future__ import unicode_literals
+from __future__ import division, unicode_literals
+
 from traits.api import Float
 
 from .function_component import (FunctionComponent,
@@ -69,7 +70,7 @@ class OpacityComponent(FunctionComponent):
             gc.set_stroke_color(BLACK)
             gc.set_fill_color(GRAY)
             gc.set_line_width(1.0)
-            gc.rect(x - COMPONENT_SIZE/2.0, y - COMPONENT_SIZE/2.0,
+            gc.rect(x - COMPONENT_SIZE/2, y - COMPONENT_SIZE/2,
                     COMPONENT_SIZE, COMPONENT_SIZE)
             gc.draw_path()
 
@@ -128,7 +129,7 @@ class OpacityComponent(FunctionComponent):
 
     def _sync_component_position(self):
         x, y = self._get_screen_position()
-        self.position = (x - COMPONENT_SIZE/2.0, y - COMPONENT_SIZE/2.0)
+        self.position = (x - COMPONENT_SIZE/2, y - COMPONENT_SIZE/2)
 
 
 # Register our function node

--- a/ensemble/ctf/tests/test_editor.py
+++ b/ensemble/ctf/tests/test_editor.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 import unittest
 
+import six
+
 from enable.testing import EnableTestAssistant
 from traits_enaml.testing.enaml_test_assistant import EnamlTestAssistant
 
@@ -21,7 +23,7 @@ class TestEditor(EnamlTestAssistant, EnableTestAssistant, unittest.TestCase):
     def setUp(self):
         EnamlTestAssistant.setUp(self)
 
-        enaml_source = b"""
+        enaml_source = """
 from enaml.widgets.api import MainWindow
 from traits_enaml.widgets.enable_canvas import EnableCanvas
 
@@ -33,7 +35,8 @@ enamldef MainView(MainWindow):
     EnableCanvas:
         component << editor
 """
-
+        if six.PY2:
+            enaml_source = enaml_source.encode('utf-8')
         editor = CtfEditor(bounds=(400, 100),
                            prompt_color_selection=get_color)
 

--- a/ensemble/ctf/utils.py
+++ b/ensemble/ctf/utils.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import division, unicode_literals
 
 import json
 
@@ -11,7 +11,7 @@ from .transfer_function import TransferFunction
 def build_screen_to_function(component):
     def func(pos):
         bounds = component.bounds
-        return tuple([clip_to_unit(z / size) for z, size in zip(pos, bounds)])
+        return tuple([clip_to_unit(z // size) for z, size in zip(pos, bounds)])
     return func
 
 

--- a/ensemble/ctf/utils.py
+++ b/ensemble/ctf/utils.py
@@ -1,7 +1,10 @@
 from __future__ import unicode_literals
+
+from io import open
 import json
 
 import numpy as np
+import six
 
 from .transfer_function import TransferFunction
 
@@ -35,7 +38,11 @@ def save_ctf(transfer_func, filename):
     """
     function_data = transfer_func.to_dict()
     with open(filename, 'wb') as fp:
-        json.dump(function_data, fp, indent=1)
+        data = json.dumps(function_data, indent=1)
+        if six.PY2:
+            fp.write(data)
+        else:
+            fp.write(data.encode('utf-8'))
 
 
 def trapezoid_window(num_points):

--- a/ensemble/ctf/utils.py
+++ b/ensemble/ctf/utils.py
@@ -11,7 +11,7 @@ from .transfer_function import TransferFunction
 def build_screen_to_function(component):
     def func(pos):
         bounds = component.bounds
-        return tuple([clip_to_unit(z // size) for z, size in zip(pos, bounds)])
+        return tuple([clip_to_unit(z / size) for z, size in zip(pos, bounds)])
     return func
 
 

--- a/ensemble/ctf/utils.py
+++ b/ensemble/ctf/utils.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 
-from io import open
 import json
 
 import numpy as np

--- a/ensemble/ctf/window_function_component.py
+++ b/ensemble/ctf/window_function_component.py
@@ -31,7 +31,7 @@ WINDOW_FUNCTIONS = {
     'trapezoid': trapezoid_window,
     'hanning': hanning,
 }
-WindowEnum = Enum(WINDOW_FUNCTIONS.keys())
+WindowEnum = Enum(list(WINDOW_FUNCTIONS.keys()))
 
 
 def _get_node(nodes, node_class):

--- a/ensemble/ctf/window_function_component.py
+++ b/ensemble/ctf/window_function_component.py
@@ -1,4 +1,5 @@
-from __future__ import unicode_literals
+from __future__ import division, unicode_literals
+
 import numpy as np
 from scipy.signal import hanning
 
@@ -139,7 +140,7 @@ class WindowHeightWidget(MovableComponent):
     def _sync_component_position(self):
         if self.container.container is not None:
             _, screen_y = self.relative_to_screen(0.0, self.node.opacity)
-            self.position = (0.0, screen_y - HEIGHT_WIDGET_THICKNESS/2.0)
+            self.position = (0.0, screen_y - HEIGHT_WIDGET_THICKNESS/2)
 
 
 class WindowComponent(BaseColorComponent):

--- a/ensemble/ctf/window_function_component.py
+++ b/ensemble/ctf/window_function_component.py
@@ -99,7 +99,7 @@ class WindowOpacityNode(OpacityNode):
 
         xs = np.linspace(center - radius, center + radius, num_samples)
         ys = self.window_func(num_samples) * self.opacity
-        return list(zip(xs, ys))
+        return zip(xs, ys)
 
     def _get_window_func(self):
         return WINDOW_FUNCTIONS[self.window_type]

--- a/ensemble/ctf/window_function_component.py
+++ b/ensemble/ctf/window_function_component.py
@@ -98,7 +98,7 @@ class WindowOpacityNode(OpacityNode):
 
         xs = np.linspace(center - radius, center + radius, num_samples)
         ys = self.window_func(num_samples) * self.opacity
-        return zip(xs, ys)
+        return list(zip(xs, ys))
 
     def _get_window_func(self):
         return WINDOW_FUNCTIONS[self.window_type]

--- a/ensemble/volren/tests/test_volume_renderer.py
+++ b/ensemble/volren/tests/test_volume_renderer.py
@@ -1,4 +1,5 @@
-from __future__ import unicode_literals
+from __future__ import division, unicode_literals
+
 import os
 import unittest
 

--- a/ensemble/volren/tests/test_volume_renderer.py
+++ b/ensemble/volren/tests/test_volume_renderer.py
@@ -3,6 +3,7 @@ import os
 import unittest
 
 import numpy as np
+import six
 
 import vtk
 from traits_enaml.testing.enaml_test_assistant import EnamlTestAssistant
@@ -27,14 +28,14 @@ def count_types(type_class, obj_list):
 
 # We use a newer version of VTK (8) which needs a newer version of OpenGL 3.2
 # which is not available on Travis CI at the moment
-@unittest.skipIf(os.environ.get('IS_CI', None), "Travis OpenGL issues")
+# @unittest.skipIf(os.environ.get('IS_CI', None), "Travis OpenGL issues")
 class VolumeViewerTestCase(EnamlTestAssistant, unittest.TestCase):
 
     def setUp(self):
 
         EnamlTestAssistant.setUp(self)
 
-        enaml_source = b"""
+        enaml_source = """
 from enaml.widgets.api import Container
 from ensemble.volren.volume_viewer_ui import VolumeViewerContainer
 
@@ -45,6 +46,8 @@ enamldef MainView(Container): view:
         viewer << view.viewer
 
 """
+        if six.PY2:
+            enaml_source = enaml_source.encode('utf-8')
         volume = np.random.normal(size=(32, 32, 32))
         volume = (255*(volume-volume.min())/volume.ptp()).astype(np.uint8)
         volume_data = VolumeData(raw_data=volume)
@@ -74,8 +77,8 @@ enamldef MainView(Container): view:
         """
         mask = np.zeros_like(volume_array)
         depth, height, width = mask.shape
-        half = (depth/2, height/2, width/2)
-        quarter = (depth/4, height/4, width/4)
+        half = (depth // 2, height // 2, width // 2)
+        quarter = (depth // 4, height // 4, width // 4)
         axis_slices = [slice(half[i]-quarter[i], half[i]+quarter[i])
                        for i in range(3)]
         mask[axis_slices[0], axis_slices[1], axis_slices[2]] = 255

--- a/ensemble/volren/tests/test_volume_renderer.py
+++ b/ensemble/volren/tests/test_volume_renderer.py
@@ -28,7 +28,7 @@ def count_types(type_class, obj_list):
 
 # We use a newer version of VTK (8) which needs a newer version of OpenGL 3.2
 # which is not available on Travis CI at the moment
-# @unittest.skipIf(os.environ.get('IS_CI', None), "Travis OpenGL issues")
+@unittest.skipIf(os.environ.get('IS_CI', None), "Travis OpenGL issues")
 class VolumeViewerTestCase(EnamlTestAssistant, unittest.TestCase):
 
     def setUp(self):

--- a/ensemble/volren/volume_cut_planes.py
+++ b/ensemble/volren/volume_cut_planes.py
@@ -1,4 +1,5 @@
-from __future__ import unicode_literals
+from __future__ import division, unicode_literals
+
 from collections import OrderedDict
 
 from mayavi import mlab
@@ -79,8 +80,8 @@ class VolumeCutPlanes(ABCVolumeSceneMember):
 
             lut_manager.use_default_range = False
             data_low, data_high = lut_manager.default_data_range
-            data_level = (data_low + data_high) / 2.0
-            data_radius = (data_high - data_low) / 2.0
+            data_level = (data_low + data_high) / 2
+            data_radius = (data_high - data_low) / 2
             level = data_level - data_radius * self.cut_brightness
             radius = data_radius * pow(2, -self.cut_contrast)
             lut_manager.data_range = (level - radius, level + radius)

--- a/ensemble/volren/volume_cut_planes.py
+++ b/ensemble/volren/volume_cut_planes.py
@@ -25,7 +25,7 @@ class VolumeCutPlanes(ABCVolumeSceneMember):
     image_plane_widget_z = Instance(PipelineBase)
 
     # Colormap selection
-    available_cut_colormaps = List(Unicode, CUT_COLORMAPS.keys())
+    available_cut_colormaps = List(Unicode, list(CUT_COLORMAPS.keys()))
     selected_cut_color_map = Enum(values='available_cut_colormaps')
 
     # A global multiplier to the opacity transfer function.

--- a/ensemble/volren/volume_data.py
+++ b/ensemble/volren/volume_data.py
@@ -1,4 +1,5 @@
-from __future__ import unicode_literals
+from __future__ import division, unicode_literals
+
 import numpy as np
 
 from traits.api import HasStrictTraits, Array, Float, Instance, Property, Tuple
@@ -46,9 +47,9 @@ def _resample_data(image_data):
     """
     spacing = image_data.spacing
     dims = image_data.dimensions
-    output_spacing = (spacing[0] * (dims[0] / 256.0),
-                      spacing[1] * (dims[1] / 256.0),
-                      spacing[2] * (dims[2] / 256.0))
+    output_spacing = (spacing[0] * (dims[0] / 256),
+                      spacing[1] * (dims[1] / 256),
+                      spacing[2] * (dims[2] / 256))
     reslicer = tvtk.ImageReslice(interpolation_mode='cubic',
                                  output_extent=(0, 255, 0, 255, 0, 255),
                                  output_spacing=output_spacing)

--- a/ensemble/volren/volume_renderer.py
+++ b/ensemble/volren/volume_renderer.py
@@ -1,4 +1,5 @@
-from __future__ import unicode_literals
+from __future__ import division, unicode_literals
+
 from mayavi.sources.vtk_data_source import VTKDataSource
 from mayavi.tools.tools import add_dataset
 from traits.api import (HasStrictTraits, CInt, Enum, Instance, List, Property,
@@ -156,7 +157,7 @@ class VolumeRenderer(HasStrictTraits):
         if self.data is None:
             return
 
-        bounds = [b/CLIP_MAX for b in self.data.bounds]
+        bounds = [b//CLIP_MAX for b in self.data.bounds]
         mn = [bounds[i]*pos for i, pos in enumerate(self.clip_bounds[::2])]
         mx = [bounds[i]*pos for i, pos in enumerate(self.clip_bounds[1::2])]
         planes = tvtk.Planes()

--- a/ensemble/volren/volume_renderer.py
+++ b/ensemble/volren/volume_renderer.py
@@ -68,7 +68,7 @@ class VolumeRenderer(HasStrictTraits):
     clip_bounds = List(CInt)
 
     # Render quality setting
-    render_quality = Enum('default', QUALITY_SETTINGS.keys())
+    render_quality = Enum('default', list(QUALITY_SETTINGS.keys()))
 
     # -------------------------------------------------------------------------
     # Public interface

--- a/ensemble/volren/volume_renderer.py
+++ b/ensemble/volren/volume_renderer.py
@@ -96,7 +96,7 @@ class VolumeRenderer(HasStrictTraits):
             color_tf.add_rgb_point(lerp(color[0]), *(color[1:]))
 
         opacity_tf = tvtk.PiecewiseFunction()
-        alphas = list(self.opacities.values())
+        alphas = self.opacities.values()
         for i, alpha in enumerate(alphas):
             x = alpha[0]
             if i > 0:

--- a/ensemble/volren/volume_renderer.py
+++ b/ensemble/volren/volume_renderer.py
@@ -96,7 +96,7 @@ class VolumeRenderer(HasStrictTraits):
             color_tf.add_rgb_point(lerp(color[0]), *(color[1:]))
 
         opacity_tf = tvtk.PiecewiseFunction()
-        alphas = self.opacities.values()
+        alphas = list(self.opacities.values())
         for i, alpha in enumerate(alphas):
             x = alpha[0]
             if i > 0:

--- a/install-edm-osx.sh
+++ b/install-edm-osx.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+install_edm() {
+    local EDM_MAJOR_MINOR="$(echo "$INSTALL_EDM_VERSION" | sed -E -e 's/([[:digit:]]+\.[[:digit:]]+)\..*/\1/')"
+    local EDM_PACKAGE="edm_${INSTALL_EDM_VERSION}.pkg"
+    local EDM_INSTALLER_PATH="${HOME}/.cache/download/${EDM_PACKAGE}"
+
+    if [ ! -e "$EDM_INSTALLER_PATH" ]; then
+        curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/osx_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
+    fi
+
+    sudo installer -pkg "$EDM_INSTALLER_PATH" -target /
+}
+
+install_edm


### PR DESCRIPTION
- encode the enaml source data in test files on python 2.
- encode the args passed to `gc.linear_context` on Python 2.
- encode the JSON data and explicitly write to file on Python 3.
- wrap calls to `dict.keys` where necessary
- test package on python 2 and 3 on travis CI